### PR TITLE
fix: add missing includes for Android build.

### DIFF
--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -1,3 +1,4 @@
+#include <android/log.h>
 #include "src/whisper.h"
 
 #define DR_WAV_IMPLEMENTATION

--- a/android/src/whisper/src/ggml/src/ggml.c
+++ b/android/src/whisper/src/ggml/src/ggml.c
@@ -1,3 +1,4 @@
+#include "../../include/whisper-version.h"
 #define _CRT_SECURE_NO_DEPRECATE // Disables "unsafe" warnings on Windows
 #define _USE_MATH_DEFINES // For M_PI on MSVC
 

--- a/android/src/whisper/src/src/whisper.cpp
+++ b/android/src/whisper/src/src/whisper.cpp
@@ -1,3 +1,4 @@
+#include "../include/whisper-version.h"
 #include "whisper.h"
 #include "whisper-arch.h"
 


### PR DESCRIPTION
The Android build fails with the following errors:

use of undeclared identifier 'GGML_VERSION'
use of undeclared identifier 'GGML_COMMIT'
use of undeclared identifier 'WHISPER_VERSION'
use of undeclared identifier 'ANDROID_LOG_DEBUG'

The file whisper-version.h exists in the Android source tree but is never included by ggml.c and whisper.cpp. Similarly, main.cpp uses __android_log_print without including <android/log.h>.

Fix:
I Added the missing includes at the top of the affected files:

android/src/whisper/src/ggml/src/ggml.c → #include "../../include/whisper-version.h"
android/src/whisper/src/src/whisper.cpp → #include "../include/whisper-version.h"
android/src/whisper/main.cpp → #include <android/log.h>

Tested on
macOS (Apple M2)
NDK 29.0.13113456
Flutter 3.x