### PR TITLE
feat: expose Whisper-detected language in transcribe response

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import ffmpeg_kit_flutter_new_min
 import record_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -507,7 +507,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -307,6 +307,18 @@ json transcribe(json jsonBody)
     }
     
     jsonResult["text"] = text_result;
+
+    // Expose the language Whisper auto-detected during transcription so callers
+    // can skip a redundant text-based language-id pass (Talkz #749). Only set
+    // when detection succeeded; absence keeps older callers' behaviour intact.
+    const int lang_id = whisper_full_lang_id(g_ctx);
+    if (lang_id >= 0) {
+        const char *lang_str = whisper_lang_str(lang_id);
+        if (lang_str != nullptr) {
+            jsonResult["language"] = std::string(lang_str);
+        }
+    }
+
     return jsonResult;
 }
 

--- a/lib/src/models/responses/whisper_transcribe_response.dart
+++ b/lib/src/models/responses/whisper_transcribe_response.dart
@@ -15,6 +15,11 @@ abstract class WhisperTranscribeResponse with _$WhisperTranscribeResponse {
     required String text,
     @JsonKey(name: 'segments')
     required List<WhisperTranscribeSegment>? segments,
+
+    /// BCP47-ish language code Whisper auto-detected for the audio (e.g. `en`,
+    /// `pt`). Null when the native layer did not report one (older builds /
+    /// detection failure), letting callers fall back to text-based language-id.
+    @JsonKey(name: 'language') String? language,
   }) = _WhisperTranscribeResponse;
 
   const WhisperTranscribeResponse._();

--- a/lib/src/models/responses/whisper_transcribe_response.freezed.dart
+++ b/lib/src/models/responses/whisper_transcribe_response.freezed.dart
@@ -20,6 +20,12 @@ mixin _$WhisperTranscribeResponse {
   @JsonKey(name: 'segments')
   List<WhisperTranscribeSegment>? get segments;
 
+  /// BCP47-ish language code Whisper auto-detected for the audio (e.g. `en`,
+  /// `pt`). Null when the native layer did not report one (older builds /
+  /// detection failure), letting callers fall back to text-based language-id.
+  @JsonKey(name: 'language')
+  String? get language;
+
   /// Create a copy of WhisperTranscribeResponse
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -38,17 +44,19 @@ mixin _$WhisperTranscribeResponse {
             other is WhisperTranscribeResponse &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.text, text) || other.text == text) &&
-            const DeepCollectionEquality().equals(other.segments, segments));
+            const DeepCollectionEquality().equals(other.segments, segments) &&
+            (identical(other.language, language) ||
+                other.language == language));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, type, text, const DeepCollectionEquality().hash(segments));
+  int get hashCode => Object.hash(runtimeType, type, text,
+      const DeepCollectionEquality().hash(segments), language);
 
   @override
   String toString() {
-    return 'WhisperTranscribeResponse(type: $type, text: $text, segments: $segments)';
+    return 'WhisperTranscribeResponse(type: $type, text: $text, segments: $segments, language: $language)';
   }
 }
 
@@ -61,7 +69,8 @@ abstract mixin class $WhisperTranscribeResponseCopyWith<$Res> {
   $Res call(
       {@JsonKey(name: '@type') String type,
       String text,
-      @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments});
+      @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments,
+      @JsonKey(name: 'language') String? language});
 }
 
 /// @nodoc
@@ -80,6 +89,7 @@ class _$WhisperTranscribeResponseCopyWithImpl<$Res>
     Object? type = null,
     Object? text = null,
     Object? segments = freezed,
+    Object? language = freezed,
   }) {
     return _then(_self.copyWith(
       type: null == type
@@ -94,6 +104,10 @@ class _$WhisperTranscribeResponseCopyWithImpl<$Res>
           ? _self.segments
           : segments // ignore: cast_nullable_to_non_nullable
               as List<WhisperTranscribeSegment>?,
+      language: freezed == language
+          ? _self.language
+          : language // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -194,15 +208,15 @@ extension WhisperTranscribeResponsePatterns on WhisperTranscribeResponse {
     TResult Function(
             @JsonKey(name: '@type') String type,
             String text,
-            @JsonKey(name: 'segments')
-            List<WhisperTranscribeSegment>? segments)?
+            @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments,
+            @JsonKey(name: 'language') String? language)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _WhisperTranscribeResponse() when $default != null:
-        return $default(_that.type, _that.text, _that.segments);
+        return $default(_that.type, _that.text, _that.segments, _that.language);
       case _:
         return orElse();
     }
@@ -223,14 +237,17 @@ extension WhisperTranscribeResponsePatterns on WhisperTranscribeResponse {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(@JsonKey(name: '@type') String type, String text,
-            @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments)
+    TResult Function(
+            @JsonKey(name: '@type') String type,
+            String text,
+            @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments,
+            @JsonKey(name: 'language') String? language)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _WhisperTranscribeResponse():
-        return $default(_that.type, _that.text, _that.segments);
+        return $default(_that.type, _that.text, _that.segments, _that.language);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -253,14 +270,14 @@ extension WhisperTranscribeResponsePatterns on WhisperTranscribeResponse {
     TResult? Function(
             @JsonKey(name: '@type') String type,
             String text,
-            @JsonKey(name: 'segments')
-            List<WhisperTranscribeSegment>? segments)?
+            @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments,
+            @JsonKey(name: 'language') String? language)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _WhisperTranscribeResponse() when $default != null:
-        return $default(_that.type, _that.text, _that.segments);
+        return $default(_that.type, _that.text, _that.segments, _that.language);
       case _:
         return null;
     }
@@ -274,7 +291,8 @@ class _WhisperTranscribeResponse extends WhisperTranscribeResponse {
       {@JsonKey(name: '@type') required this.type,
       required this.text,
       @JsonKey(name: 'segments')
-      required final List<WhisperTranscribeSegment>? segments})
+      required final List<WhisperTranscribeSegment>? segments,
+      @JsonKey(name: 'language') this.language})
       : _segments = segments,
         super._();
   factory _WhisperTranscribeResponse.fromJson(Map<String, dynamic> json) =>
@@ -295,6 +313,13 @@ class _WhisperTranscribeResponse extends WhisperTranscribeResponse {
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
+
+  /// BCP47-ish language code Whisper auto-detected for the audio (e.g. `en`,
+  /// `pt`). Null when the native layer did not report one (older builds /
+  /// detection failure), letting callers fall back to text-based language-id.
+  @override
+  @JsonKey(name: 'language')
+  final String? language;
 
   /// Create a copy of WhisperTranscribeResponse
   /// with the given fields replaced by the non-null parameter values.
@@ -320,17 +345,19 @@ class _WhisperTranscribeResponse extends WhisperTranscribeResponse {
             other is _WhisperTranscribeResponse &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.text, text) || other.text == text) &&
-            const DeepCollectionEquality().equals(other._segments, _segments));
+            const DeepCollectionEquality().equals(other._segments, _segments) &&
+            (identical(other.language, language) ||
+                other.language == language));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, type, text, const DeepCollectionEquality().hash(_segments));
+  int get hashCode => Object.hash(runtimeType, type, text,
+      const DeepCollectionEquality().hash(_segments), language);
 
   @override
   String toString() {
-    return 'WhisperTranscribeResponse(type: $type, text: $text, segments: $segments)';
+    return 'WhisperTranscribeResponse(type: $type, text: $text, segments: $segments, language: $language)';
   }
 }
 
@@ -345,7 +372,8 @@ abstract mixin class _$WhisperTranscribeResponseCopyWith<$Res>
   $Res call(
       {@JsonKey(name: '@type') String type,
       String text,
-      @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments});
+      @JsonKey(name: 'segments') List<WhisperTranscribeSegment>? segments,
+      @JsonKey(name: 'language') String? language});
 }
 
 /// @nodoc
@@ -364,6 +392,7 @@ class __$WhisperTranscribeResponseCopyWithImpl<$Res>
     Object? type = null,
     Object? text = null,
     Object? segments = freezed,
+    Object? language = freezed,
   }) {
     return _then(_WhisperTranscribeResponse(
       type: null == type
@@ -378,6 +407,10 @@ class __$WhisperTranscribeResponseCopyWithImpl<$Res>
           ? _self._segments
           : segments // ignore: cast_nullable_to_non_nullable
               as List<WhisperTranscribeSegment>?,
+      language: freezed == language
+          ? _self.language
+          : language // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }

--- a/lib/src/models/responses/whisper_transcribe_response.g.dart
+++ b/lib/src/models/responses/whisper_transcribe_response.g.dart
@@ -15,6 +15,7 @@ _WhisperTranscribeResponse _$WhisperTranscribeResponseFromJson(
           ?.map((e) =>
               WhisperTranscribeSegment.fromJson(e as Map<String, dynamic>))
           .toList(),
+      language: json['language'] as String?,
     );
 
 Map<String, dynamic> _$WhisperTranscribeResponseToJson(
@@ -23,4 +24,5 @@ Map<String, dynamic> _$WhisperTranscribeResponseToJson(
       '@type': instance.type,
       'text': instance.text,
       'segments': instance.segments,
+      'language': instance.language,
     };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -322,10 +322,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

`whisper_full()` already auto-detects the spoken language during transcription, but the FFI layer drops it — `WhisperTranscribeResponse` only exposes `{@type, text, segments}`. This adds the detected language as an optional `language` field.

## Why

Apps that transcribe then translate currently have to run a **second, text-based** language-id pass over the transcript to pick the source language — redundant, since Whisper already knows the audio language. Surfacing it lets callers skip that hop.

## Changes

- `ios/Classes/whisper_flutter_plus.cpp` (the shared FFI source for iOS/macOS/Android): after building the result, call `whisper_full_lang_id()` → `whisper_lang_str()` and add `jsonResult["language"]` when detection succeeds (`lang_id >= 0`).
- `lib/src/models/responses/whisper_transcribe_response.dart`: add `@JsonKey(name: 'language') String? language` to `WhisperTranscribeResponse`; regenerated `.freezed.dart` / `.g.dart`.

## Compatibility

Fully backward compatible — the field is **optional/nullable**. Older native binaries (or detection failure) simply leave it `null`, so existing callers are unaffected. No FFI signature change (it rides the existing JSON channel).